### PR TITLE
Rework quality at glance

### DIFF
--- a/master/pyext/src/validation/get_plots.py
+++ b/master/pyext/src/validation/get_plots.py
@@ -14,7 +14,7 @@ import bokeh
 import numpy as np
 from bokeh.io import output_file, curdoc, export_png, export_svgs, show
 from bokeh.models import (ColumnDataSource, Legend, LegendItem, FactorRange,
-    Div, BasicTickFormatter)
+                          Div, BasicTickFormatter)
 from bokeh.palettes import viridis, Reds256, linear_palette
 from bokeh.plotting import figure, save
 from bokeh.models.widgets import Tabs, Panel
@@ -75,15 +75,15 @@ class Plots(validation.GetInputInformation):
                     x_range=(0, upper),
                     plot_height=120,
                     plot_width=700
-                    )
+                )
 
                 p.hbar(y=source.data['y'][i * 3: (i + 1) * 3],
-                    right=source.data['counts'][i * 3: (i + 1) * 3],
-                    width=0.9, line_color="white",
-                    fill_color=factor_cmap('y', palette=viridis(len(Scores)),
-                    factors=Scores,
-                    start=1, end=2)
-                   )
+                       right=source.data['counts'][i * 3: (i + 1) * 3],
+                       width=0.9, line_color="white",
+                       fill_color=factor_cmap('y', palette=viridis(len(Scores)),
+                                              factors=Scores,
+                                              start=1, end=2)
+                       )
                 # set labels and fonts
                 p.xaxis.major_label_text_font_size = "12pt"
                 p.yaxis.major_label_text_font_size = "12pt"
@@ -97,20 +97,20 @@ class Plots(validation.GetInputInformation):
                 plots.append(p)
 
                 export_svgs(p, filename=self.filename+'/' +
-                   self.ID+'_' + str(i) + "_quality_at_glance_MQ.svg")
+                            self.ID+'_' + str(i) + "_quality_at_glance_MQ.svg")
 
             grid = gridplot(plots, ncols=1,
-                merge_tools=True,
-                toolbar_location='right')
+                            merge_tools=True,
+                            toolbar_location='right')
             grid.children[1].css_classes = ['scrollable']
             grid.children[1].sizing_mode = 'fixed'
             grid.children[1].height = 450
             grid.children[1].width = 800
 
             title = Div(text="<p>Model Quality: Molprobity Analysis</p>",
-                style={"font-size": "1.5em", "font-weight": "bold",
-                "text-align": "center", "width": '100%'}, width=800
-                )
+                        style={"font-size": "1.5em", "font-weight": "bold",
+                               "text-align": "center", "width": '100%'}, width=800
+                        )
 
             fullplot = column(title, grid)
 
@@ -133,7 +133,6 @@ class Plots(validation.GetInputInformation):
             source = ColumnDataSource(
                 data=dict(Scores=Scores, counts=counts, legends=legends, color=viridis(n)))
 
-
             #  build plots
             plots = []
 
@@ -142,7 +141,7 @@ class Plots(validation.GetInputInformation):
 
             for i, name_ in enumerate(model):
                 p = figure(y_range=source.data['Scores'][i: i + 1], x_range=(lower, upper), plot_height=100,
-                           plot_width=700) # , title='Model Quality: Excluded Volume Analysis')
+                           plot_width=700)  # , title='Model Quality: Excluded Volume Analysis')
                 # p.xaxis.formatter = BasicTickFormatter(use_scientific=True, power_limit_high=3)
                 p.xaxis.ticker.desired_num_ticks = 3
 
@@ -150,8 +149,8 @@ class Plots(validation.GetInputInformation):
                            alpha=0.8, line_color='black')
                 p.xaxis.axis_label = 'Number of violations'
                 legend = Legend(items=[LegendItem(label=legends[i:i + 1][j], renderers=[
-                            r], index=j) for j in range(len(legends[i:i + 1]))], location='center',
-                            label_text_font_size='12px', orientation='vertical')
+                    r], index=j) for j in range(len(legends[i:i + 1]))], location='center',
+                    label_text_font_size='12px', orientation='vertical')
                 p.add_layout(legend, 'right')
                 p.xaxis.major_label_text_font_size = "12pt"
                 p.yaxis.major_label_text_font_size = "12pt"
@@ -161,20 +160,20 @@ class Plots(validation.GetInputInformation):
                 plots.append(p)
 
                 export_svgs(p, filename=self.filename+'/' +
-                   self.ID+'_' + str(i) + "_quality_at_glance_MQ.svg")
+                            self.ID+'_' + str(i) + "_quality_at_glance_MQ.svg")
 
             grid = gridplot(plots, ncols=1,
-                merge_tools=True,
-                toolbar_location='right')
+                            merge_tools=True,
+                            toolbar_location='right')
             grid.children[1].css_classes = ['scrollable']
             grid.children[1].sizing_mode = 'fixed'
             grid.children[1].height = 450
             grid.children[1].width = 800
 
             title = Div(text='<p>Model Quality: Excluded Volume Analysis</p>',
-                style={"font-size": "1.5em", "font-weight": "bold",
-                "text-align": "center", "width": '100%'}, width=800
-                )
+                        style={"font-size": "1.5em", "font-weight": "bold",
+                               "text-align": "center", "width": '100%'}, width=800
+                        )
 
             fullplot = column(title, grid)
 
@@ -204,8 +203,9 @@ class Plots(validation.GetInputInformation):
         export_svgs(fullplot, filename=self.filename+'/' +
                     self.ID+"quality_at_glance_MQ.svg")
         export_png(fullplot, filename=self.filename+'/' +
-                    self.ID+"quality_at_glance_MQ.png")
-        save(fullplot, filename=self.filename+'/'+self.ID+"quality_at_glance_MQ.html")
+                   self.ID+"quality_at_glance_MQ.png")
+        save(fullplot, filename=self.filename+'/' +
+             self.ID+"quality_at_glance_MQ.html")
         # DATA QUALITY
         # check for sas data, if exists, plot
         # this section will be updated with more data assessments, as and when it is complete

--- a/master/pyext/src/validation/utility.py
+++ b/master/pyext/src/validation/utility.py
@@ -488,3 +488,54 @@ def clean_all():
             os.remove(item)
         if item.endswith('.sascif'):
             os.remove(item)
+
+
+# Adapted from
+# https://stackoverflow.com/questions/52859751/
+# most-efficient-way-to-find-order-of-magnitude-of-float-in-python
+def order_of_magnitude(value: float) -> float:
+    '''
+    calculate the order of magnitude for a given number
+
+    >>> order_of_magnitude(135)
+    2.0
+
+    '''
+    if value <= 0:
+        raise(f'Wrong value: {value}. '
+              'This function works only for positive values')
+    return np.floor(np.log10(value))
+
+
+def calc_optimal_range(counts: list) -> tuple:
+    '''
+    heuristics to find optimal range for plots
+
+    >>> calc_optimal_range((10, 1567))
+    (9.0, 1568.5669999999998)
+
+    '''
+
+    # Find min/max values
+    upper = max(counts)
+    lower = min(counts)
+
+    # In peculiar cases add an arbitary offset to the range
+    if upper == 0:
+        upper = 10
+        lower = 0
+
+    # Find the data's order of magnitude and make offset.
+    # Typically it would be .001%
+    if upper > 0:
+        oom = order_of_magnitude(upper)
+        upper = upper * (1 + 10 ** (-oom))
+
+    if lower > 0:
+        oom = order_of_magnitude(lower)
+        # Do not allow the range to go below zero
+        lower = max(0, lower * (1 - 10 ** (-oom)))
+
+    assert lower >= 0 and upper > 0
+
+    return(lower, upper)

--- a/templates/main.html
+++ b/templates/main.html
@@ -64,7 +64,7 @@
                                                                         <div class="row">
                                                                             <div class="col-lg-12">
                                                                                 <script type="text/javascript">
-                                                                                    var tex='<div class="card-header" style="background-color: #FFFFFF; border-color:#003366; height: 90rem;">'
+                                                                                    var tex='<div class="card-header" style="background-color: #FFFFFF; border-color:#003366;">'
                                                                                     document.write(tex);
                                                                                 </script>
 
@@ -139,7 +139,7 @@
                                                                                                         <script type="text/javascript">
 
                                                                                                         if ({{disclaimer}}==0){
-                                                                                                            var section = '<iframe src=../images/' + {{ID_w}} + 'quality_at_glance_MQ.html frameborder=0 scrolling=yes width=100% height=1250vh align=center text-align: center style=position:relative></iframe>'
+                                                                                                            var section = '<iframe src=../images/' + {{ID_w}} + 'quality_at_glance_MQ.html frameborder=0 scrolling=yes width=90% align=center text-align: center style="position:relative; min-height:470px; max-height:2048px;"></iframe>'
                                                                                                             document.write(section); }
 
                                                                                                         </script>
@@ -156,7 +156,7 @@
                                                                                                 <div id="menu2" class="tab-pane fade">
                                                                                                     <div class="box text-center container-fluid no-padding" align='center'>
                                                                                                         <script>
-                                                                                                            var section = '<iframe src=../images/' + {{ID_w}} + 'quality_at_glance_FQ.html frameborder=0 scrolling=yes width=90% height=500vh align=center text-align: center style=position:relative></iframe>'
+                                                                                                            var section = '<iframe src=../images/' + {{ID_w}} + 'quality_at_glance_FQ.html frameborder=0 scrolling=yes width=90% align=center text-align: center style="position:relative; min-height:470px; max-height:2048px;"></iframe>'
                                                                                                             document.write(section);
                                                                                                         </script>
                                                                                                     </div>
@@ -181,19 +181,12 @@
                                                                                 <p style=margin-bottom:1cm;> </p>
                                                                                 <p align="justify">The following software was used in the production of this report.</p>
                                                                                 <ul style="list-style-type:none;">
-                                                                                    <script>
-                                                                                        var s = 0
-                                                                                        if (s < 1) {
-                                                                                            var docx = "<li><em><a href='http://molprobity.biochem.duke.edu/'>Molprobity</a> Version 4.4</em></li>";
-                                                                                            document.write(docx);
-                                                                                        }
-                                                                                        if ({{sas}}.length > 0 && {{sasdb_sascif}}.length > 0){
+                                                                                    <li><em><a href='http://molprobity.biochem.duke.edu/'>Molprobity</a> Version 4.4</em></li>
+                                                                                        
+																					{% if sas|length > 0 and sasdb_sascif|length > 0 %}
+                                                                                   	  <li><em><a href='https://www.embl-hamburg.de/biosaxs/software.html'>ATSAS</a>  Version 3.0.3</em></li>
+																					{% endif %}
 
-                                                                                            var docx = "<li><em><a href='https://www.embl-hamburg.de/biosaxs/software.html'>ATSAS</a>  Version 3.0.3</em></li>";
-                                                                                            document.write(docx);
-
-                                                                                        }
-                                                                                    </script>
                                                                                     <li><em><a href='https://github.com/salilab/IHMValidation'>Integrative Modeling Validation</a>  Version 1.0</em></li>
                                                                                     <li><em><a href='https://integrativemodeling.org/'>Integrative Modeling Platform</a> Version 2.15.0</em></li>
 

--- a/templates/template_pdf.html
+++ b/templates/template_pdf.html
@@ -257,38 +257,40 @@
                     <h3 align="center"><a name='qual'><u>Overall quality</u></a>  <a class='help1' style="background-color:#228B22;color:#000000;text-decoration:none font-size=16px" href="https://pdb-dev-beta.wwpdb.org/validation_help.html#overview">?</a></h3>
                     <p align="justify"> <em>This validation report contains model quality assessments for all structures, data quality assessment for SAS datasets and fit to model assessments for SAS datasets. Data quality and fit to model assessments for other datasets and model uncertainty are under development.</em> </p>
 
-                    <div class="box text-center container-fluid no-padding" align='center'>
-                        <script>
-                            if ({{NumModels}}>10 && {{disclaimer}}==0){
-                            var section = '<iframe src=../images/' + {{ID_w}}  + 'quality_at_glance_MQ.svg onload=javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+px;}(this)); style=height:1310px;width:100%;border:none;overflow:hidden;></iframe>'
-                            document.write(section);
-                        } else if ({{NumModels}}<10 && {{disclaimer}} == 0) {
-                            var section = '<iframe src=../images/' + {{ID_w}}  + 'quality_at_glance_MQ.svg onload=javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+px;}(this)); style=height:510px;width:100%;border:none;overflow:hidden;></iframe>'
-                                document.write(section);
+                    <div class="box text-center container-fluid no-padding" align='center' style="break-inside: avoid;">
+                      {% if disclaimer == 0 %}
+												{% if assess_excluded_volume[0] == 'Not applicable' %}
+													<p><h5><b>Model Quality: Molprobity Analysis</b></h5></p>
+												{% else %}
+													<p><h5><b>Model Quality: Excluded Volume Analysis</b></h5></p>
+												{% endif %}
 
-                        } else if ({{disclaimer}}==1) {
-
-                            var docx='<p align="justify"><em>Molprobity assessments and/or excluded volume assessments can not be evaluated for this current model.</em></p>'
-                            document.write(docx)
-
-                            }
-                        </script>
+												{% for i in range(NumModels) %}
+													<div><object width=100% data={{ "../images/" ~ ID_w[0] ~ '_' ~ i ~ '_quality_at_glance_MQ.svg'}}></object></div>
+												{% endfor %}
+											{% elif disclaimer == 1 -%}
+												<p align="justify"><em>Molprobity assessments and/or excluded volume assessments can not be evaluated for this current model.</em></p>
+											{% endif %}
                     </div>
                 </div>
             </div>
         </div>
     </div>
 
-    <script>
-        if ({{sas}}.length > 0 && {{sasdb_sascif}}.length > 0) {
-            var sec='<div class="card-body"><div class="row"><div class="col-lg-12"><div class="card-header" style="background-color: #FFFFFF ;"><div class="box text-center container-fluid no-padding" align="center">'
-            document.write(sec);
-            var section = '<iframe src=../images/' + {{ID_w}}  + 'quality_at_glance_DQ.svg onload=javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+px;}(this)); style=height:510px;width:100%;border:none;overflow:hidden;></iframe>'
-            document.write(section);
-            var sec2='</div></div></div></div></div>'
-            document.write(sec2);}
-        </script>
-
+    {% if ( (sas|length > 0) and (sasdb_sascif|length > 0) ) %}
+    	<div class="card-body">
+				<div class="row">
+					<div class="col-lg-12">
+						<div class="card-header" style="background-color: #FFFFFF ;">
+							<div class="box text-center container-fluid no-padding" align="center">
+								<iframe src={{"../images/" ~ ID_w[0]  ~ "quality_at_glance_DQ.svg"}} onload="javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+px;}(this));" style="height:510px;width:100%;border:none;overflow:hidden;">
+								</iframe>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		{% endif %}
         <script>
             if ({{number_of_fits}}  > 0 && {{sasdb_sascif}}.length > 0) {
                 var sec='<div class="card-body"><div class="row"><div class="col-lg-12"><div class="card-header" style="background-color: #FFFFFF ;"><div class="box text-center container-fluid no-padding" align="center">'
@@ -441,6 +443,7 @@
                                 } else {
                                     var write_prot = "<i>This entry is a result of " + {{Protocols_number}} + " distinct protocols.</i>";
                                     document.write(write_prot);
+									}
                                 </script>
                                 <p class="ex2"> </p>
                                 <script>


### PR DESCRIPTION
Major update for the quality at a glance page. Fixes scaling of bokeh plots, especially for multimode entries. Also introduces a routine to estimate data ranges for plots (related to #27) and replaces some bits of the js code with pure jinja2 (related to #19).

Sorry for this blob-style update, it is really hard to dissect it in smaller patches keeping everything working. 